### PR TITLE
improve error handling for both API versions

### DIFF
--- a/lib/ex_activecampaign/api_v1.ex
+++ b/lib/ex_activecampaign/api_v1.ex
@@ -229,11 +229,11 @@ defmodule ExActivecampaign.ApiV1 do
   def clean_params(query_params) when query_params == %{}, do: []
   def clean_params(query_params), do: [{:params, query_params}]
 
-  def handle_response({status, body} = _resp) do
-    case status do
-      200 -> body
-      x when x in 400..499 -> %{error_message: "Bad Request"}
-      x when x in 500..599 -> %{error_message: "Internal Server Error"}
+  def handle_response({_status, body} = _resp) do
+    # V1 of the API always returns a 200 status code, and uses a field in the response to indicate success or failure
+    case body["result_code"] do
+      0 -> %{error_message: body["result_message"]}
+      1 -> body
       _ -> %{error_message: "Unknown Error"}
     end
   end

--- a/lib/ex_activecampaign/api_v3.ex
+++ b/lib/ex_activecampaign/api_v3.ex
@@ -247,13 +247,17 @@ defmodule ExActivecampaign.ApiV3 do
 
   def handle_response({status, body} = _resp) do
     case status do
-      200 -> body
-      201 -> body
-      400 -> %{error_message: "Bad Request"}
-      403 -> %{error_message: "Forbidden"}
-      404 -> %{error_message: "Not Found"}
-      422 -> %{error_message: "Unprocessable Entity"}
-      500 -> %{error_message: "Internal Server Error"}
+      x when x in 200..299 ->
+        body
+
+      x when x in 400..499 ->
+        %{error_message: "Bad Request", errors: body.errors}
+
+      x when x in 500..599 ->
+        %{error_message: "Internal Server Error"}
+
+      _ ->
+        %{error_message: "Unknown Error"}
     end
   end
 end

--- a/lib/ex_activecampaign/contact.ex
+++ b/lib/ex_activecampaign/contact.ex
@@ -33,7 +33,7 @@ defmodule ExActivecampaign.Contact do
       %{contact: %{email: "johndoe@example.com", firstName: "John", id: "1", lastName: "Doe", phone: "7223224241"}}
 
       iex> ExActivecampaign.Contact.create(%{"email" => "1234", "first_name" => "John", "last_name" => "Doe", "phone" => "7223224241"})
-      %{error_message: "Unprocessable Entity"}
+      %{error_message: "Bad Request", errors: [%{"title": "Contact Email Address is not valid.", "detail": "", "code": "email_invalid", "error": "must_be_valid_email_address", "source": %{"pointer": "/data/attributes/email"}}]}
 
       iex> ExActivecampaign.Contact.create(%{"phone" => "1234"})
       ** (FunctionClauseError) no function clause matching in ExActivecampaign.Contact.create/1
@@ -64,7 +64,7 @@ defmodule ExActivecampaign.Contact do
       %{contact: %{email: "johndoe@example.com", firstName: "John", id: "1", lastName: "Doe", phone: "7223224241"}}
 
       iex> ExActivecampaign.Contact.create_or_update(%{"email" => "1234", "first_name" => "John", "last_name" => "Doe", "phone" => "7223224241"})
-      %{error_message: "Unprocessable Entity"}
+      %{error_message: "Bad Request", errors: [%{"title": "Contact Email Address is not valid.", "detail": "", "code": "email_invalid", "error": "must_be_valid_email_address", "source": %{"pointer": "/data/attributes/email"}}]}
 
       iex> ExActivecampaign.Contact.create_or_update(%{"phone" => "1234"})
       ** (FunctionClauseError) no function clause matching in ExActivecampaign.Contact.create_or_update/1
@@ -96,7 +96,7 @@ defmodule ExActivecampaign.Contact do
       %{contact: %{email: "johndoe@example.com", firstName: "John", id: "80480", lastName: "Doe", phone: "7223224241"}}
 
       iex> ExActivecampaign.Contact.update(80480, %{"email" => "1234", "first_name" => "John", "last_name" => "Doe", "phone" => "7223224241"})
-      %{error_message: "Unprocessable Entity"}
+      %{error_message: "Bad Request", errors: [%{"title": "Contact Email Address is not valid.", "detail": "", "code": "email_invalid", "error": "must_be_valid_email_address", "source": %{"pointer": "/data/attributes/email"}}]}
   """
   def update(contact_id, params) do
     ApiV3.post(
@@ -166,13 +166,13 @@ defmodule ExActivecampaign.Contact do
       %{contact: %{id: "1", email: "johndoe@example.com", firstName: "John", lastName: "Doe", phone: "7223224241"}, contactLists: []}
 
       iex> ExActivecampaign.Contact.retrieve(101)
-      %{error_message: "Not Found"}
+      %{error_message: "Bad Request", errors: [%{code: "related_missing", detail: "", error: "contact_not_exist", source: %{pointer: "/data/attributes/contact"}, title: "The related contact does not exist."}]}
 
       iex> ExActivecampaign.Contact.retrieve("johndoe@example.com")
       %{contact: %{id: "1", email: "johndoe@example.com", firstName: "John", lastName: "Doe", phone: "7223224241"}, contactLists: []}
 
       iex> ExActivecampaign.Contact.retrieve("some-invalid-email")
-      %{error_message: "Not Found"}
+      %{error_message: "Bad Request", errors: [%{code: "related_missing", detail: "", error: "contact_not_exist", source: %{pointer: "/data/attributes/contact"}, title: "The related contact does not exist."}]}
   """
   def retrieve(id) when is_integer(id) do
     ApiV3.get(ExActivecampaign.base_url_v3() <> "/contacts/#{id}", %{}, [])
@@ -205,10 +205,13 @@ defmodule ExActivecampaign.Contact do
       %{contactList: %{contact: "1", list: "1", status: 0}, contacts: [%{email: "johndoe@example.com", firstName: "John", id: "1", lastName: "Doe", phone: "7223224241"}]}
 
       iex> ExActivecampaign.Contact.update_list_status(%{contact: "invalid-contact", list: 1, status: 1})
-      %{error_message: "Bad Request"}
+      %{error_message: "Bad Request", errors: [%{code: "related_missing", detail: "", error: "contact_not_exist", source: %{pointer: "/data/attributes/contact"}, title: "The related contact does not exist."}]}
 
       iex> ExActivecampaign.Contact.update_list_status(%{contact: 1, list: "invalid-list", status: 1})
-      %{error_message: "Bad Request"}
+      %{error_message: "Bad Request", errors: [%{title: "The related list does not exist.", detail: "", code: "related_missing", error: "list_not_exist", source: %{pointer: "/data/attributes/list"}}]}
+
+      iex> ExActivecampaign.Contact.update_list_status(%{contact: "invalid-contact", list: "invalid-list", status: 1})
+      %{error_message: "Bad Request", errors: [%{title: "The related list does not exist.", detail: "", code: "related_missing", error: "list_not_exist", source: %{pointer: "/data/attributes/list"}}, %{title: "The related contact does not exist.", detail: "", code: "related_missing", error: "contact_not_exist", source: %{pointer: "/data/attributes/contact"}}]}
 
       iex> ExActivecampaign.Contact.update_list_status(%{contact: 1, list: 1, status: "invalid-status"})
       %{error_message: "Status must be one of: 0 (unconfirmed), 1 (active), 2 (unsubscribed), 3 (active)"}

--- a/lib/ex_activecampaign/list.ex
+++ b/lib/ex_activecampaign/list.ex
@@ -17,7 +17,7 @@ defmodule ExActivecampaign.List do
       %{list: %{stringid: "example-list", name: "Example List", id: "1"}}
 
       iex> ExActivecampaign.List.retrieve("some-invalid-list-id")
-      %{error_message: "Not Found"}
+      %{error_message: "Bad Request", errors: [%{code: "related_missing", detail: "", error: "list_not_exist", source: %{pointer: "/data/attributes/list"}, title: "The related list does not exist."}]}
   """
   def retrieve(id) do
     ApiV3.get(ExActivecampaign.base_url_v3() <> "/lists/#{id}", %{}, [])


### PR DESCRIPTION
API v1:
- always returns a 200 status code, and uses a field in the response to indicate success or failure 🤮

API v3:
- if the API responds to a request with a 400-series status code, now returns a List containing the cause of all errors in the request

Mock Server:
- now returns more realistic errors for failed requests