### PR TITLE
bugfix - handle case where body is not a map

### DIFF
--- a/lib/ex_activecampaign/api_v1.ex
+++ b/lib/ex_activecampaign/api_v1.ex
@@ -239,7 +239,6 @@ defmodule ExActivecampaign.ApiV1 do
   end
 
   def handle_response({_status, body} = _resp) do
-    {error_message: "Expected a map, got #{inspect(body)}"}
-    end
+    %{error_message: "Expected a map, got #{inspect(body)}"}
   end
 end

--- a/lib/ex_activecampaign/api_v1.ex
+++ b/lib/ex_activecampaign/api_v1.ex
@@ -229,12 +229,17 @@ defmodule ExActivecampaign.ApiV1 do
   def clean_params(query_params) when query_params == %{}, do: []
   def clean_params(query_params), do: [{:params, query_params}]
 
-  def handle_response({_status, body} = _resp) do
+  def handle_response({_status, body} = _resp) when is_map(body) do
     # V1 of the API always returns a 200 status code, and uses a field in the response to indicate success or failure
     case body["result_code"] do
       0 -> %{error_message: body["result_message"]}
       1 -> body
       _ -> %{error_message: "Unknown Error"}
+    end
+  end
+
+  def handle_response({_status, body} = _resp) do
+    {error_message: "Expected a map, got #{inspect(body)}"}
     end
   end
 end

--- a/test/mocks/mock_server.ex
+++ b/test/mocks/mock_server.ex
@@ -58,21 +58,21 @@ defmodule ExActivecampaign.MockServer do
   defp get_failure_contact_not_found(conn) do
     conn
     |> Plug.Conn.send_resp(
-         404,
-         Poison.encode!(%{
-           errors: [
-             %{
-               title: "The related contact does not exist.",
-               detail: "",
-               code: "related_missing",
-               error: "contact_not_exist",
-               source: %{
-                 pointer: "/data/attributes/contact"
-               }
-             }
-           ]
-         })
-       )
+      404,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "The related contact does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "contact_not_exist",
+            source: %{
+              pointer: "/data/attributes/contact"
+            }
+          }
+        ]
+      })
+    )
   end
 
   post "/v3/contacts" do
@@ -95,19 +95,22 @@ defmodule ExActivecampaign.MockServer do
 
   defp post_failure_email_address_invalid(conn) do
     conn
-    |> Plug.Conn.send_resp(400, Poison.encode!(%{
-      errors: [
-        %{
-          title: "Contact Email Address is not valid.",
-          detail: "",
-          code: "email_invalid",
-          error: "must_be_valid_email_address",
-          source: %{
-            pointer: "/data/attributes/email"
+    |> Plug.Conn.send_resp(
+      400,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "Contact Email Address is not valid.",
+            detail: "",
+            code: "email_invalid",
+            error: "must_be_valid_email_address",
+            source: %{
+              pointer: "/data/attributes/email"
+            }
           }
-        }
-      ]
-    }))
+        ]
+      })
+    )
   end
 
   post "/v3/contact/sync" do
@@ -208,7 +211,13 @@ defmodule ExActivecampaign.MockServer do
       %{"contactList" => %{"list" => 1, "contact" => "invalid-contact", "status" => 1}} ->
         post_failure_bad_request_invalid_contact(conn)
 
-      %{"contactList" => %{"list" => "invalid-list", "contact" => "invalid-contact", "status" => 1}} ->
+      %{
+        "contactList" => %{
+          "list" => "invalid-list",
+          "contact" => "invalid-contact",
+          "status" => 1
+        }
+      } ->
         post_failure_bad_request_invalid_list_and_contact(conn)
 
       %{"contactList" => %{"list" => 1, "contact" => 1, "status" => "invalid-status"}} ->
@@ -218,62 +227,71 @@ defmodule ExActivecampaign.MockServer do
 
   defp post_failure_bad_request_invalid_list(conn) do
     conn
-    |> Plug.Conn.send_resp(400, Poison.encode!(%{
-      errors: [
-        %{
-          title: "The related list does not exist.",
-          detail: "",
-          code: "related_missing",
-          error: "list_not_exist",
-          source: %{
-            pointer: "/data/attributes/list"
+    |> Plug.Conn.send_resp(
+      400,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "The related list does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "list_not_exist",
+            source: %{
+              pointer: "/data/attributes/list"
+            }
           }
-        }
-      ]
-    }))
+        ]
+      })
+    )
   end
 
   defp post_failure_bad_request_invalid_contact(conn) do
     conn
-    |> Plug.Conn.send_resp(400, Poison.encode!(%{
-      errors: [
-        %{
-          title: "The related contact does not exist.",
-          detail: "",
-          code: "related_missing",
-          error: "contact_not_exist",
-          source: %{
-            pointer: "/data/attributes/contact"
+    |> Plug.Conn.send_resp(
+      400,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "The related contact does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "contact_not_exist",
+            source: %{
+              pointer: "/data/attributes/contact"
+            }
           }
-        }
-      ]
-    }))
+        ]
+      })
+    )
   end
 
   defp post_failure_bad_request_invalid_list_and_contact(conn) do
     conn
-    |> Plug.Conn.send_resp(400, Poison.encode!(%{
-      errors: [
-        %{
-          title: "The related list does not exist.",
-          detail: "",
-          code: "related_missing",
-          error: "list_not_exist",
-          source: %{
-            pointer: "/data/attributes/list"
+    |> Plug.Conn.send_resp(
+      400,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "The related list does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "list_not_exist",
+            source: %{
+              pointer: "/data/attributes/list"
+            }
+          },
+          %{
+            title: "The related contact does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "contact_not_exist",
+            source: %{
+              pointer: "/data/attributes/contact"
+            }
           }
-        },
-        %{
-          title: "The related contact does not exist.",
-          detail: "",
-          code: "related_missing",
-          error: "contact_not_exist",
-          source: %{
-            pointer: "/data/attributes/contact"
-          }
-        }
-      ]
-    }))
+        ]
+      })
+    )
   end
 
   get "/v3/lists/:id" do
@@ -300,21 +318,21 @@ defmodule ExActivecampaign.MockServer do
   defp get_failure_list_not_found(conn) do
     conn
     |> Plug.Conn.send_resp(
-         404,
-         Poison.encode!(%{
-           errors: [
-             %{
-               title: "The related list does not exist.",
-               detail: "",
-               code: "related_missing",
-               error: "list_not_exist",
-               source: %{
-                 pointer: "/data/attributes/list"
-               }
-             }
-           ]
-         })
-       )
+      404,
+      Poison.encode!(%{
+        errors: [
+          %{
+            title: "The related list does not exist.",
+            detail: "",
+            code: "related_missing",
+            error: "list_not_exist",
+            source: %{
+              pointer: "/data/attributes/list"
+            }
+          }
+        ]
+      })
+    )
   end
 
   post "/v1" do


### PR DESCRIPTION
```
{:error, %HTTPoison.Error{id: nil, reason: :timeout}}
```
For the HTTPoison error above (or any with an atom as the reason) calling `ApiV1.handle_case/1` will result in a `FunctionClauseError`, i.e. when the reason is `:timeout`, 

```
** (FunctionClauseError) no function clause matching in Access.get/3

    The following arguments were given to Access.get/3:

        # 1
        :timeout

        # 2
        "result_code"

        # 3
        nil

    Attempted function clauses (showing 5 out of 5):

        def get(%module{} = container, key, default)
        def get(map, key, default) when is_map(map)
        def get(list, key, default) when is_list(list) and is_atom(key)
        def get(list, key, _default) when is_list(list)
        def get(nil, _key, default)

    (elixir 1.10.3) lib/access.ex:284: Access.get/3
```